### PR TITLE
Update bup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ RUN apt-get update && apt-get -y install unzip
 RUN docker-php-ext-install mysqli
 
 # download and unzip current CourtSpot
-RUN curl -O 'https://www.courtspot.de/Downloads/CourtSpot.zip' -o /var/www/html/CourtSpot.zip
+RUN curl 'https://www.courtspot.de/Downloads/CourtSpot.zip' -o /var/www/html/CourtSpot.zip
 RUN unzip /var/www/html/CourtSpot.zip -d  /var/www/html/
+
+# Update bup
+RUN curl -s https://aufschlagwechsel.de/bup/div/bupdate.txt -o /var/www/html/CourtSpot/Update-Verzeichnis/bupdate.php
+RUN php /var/www/html/CourtSpot/Update-Verzeichnis/bupdate.php
 
 # change document root to unzipped CourtSpot folder
 ENV APACHE_DOCUMENT_ROOT /var/www/html/CourtSpot


### PR DESCRIPTION
bup has its own release schedule, independent of CourtSpot. It is updated much more frequently (remaining backwards-compatible even to older CourtSpot versions, letalone the newest one).
Update bup and bupdate.php itself.

(Also remove a meaningless -O from a neighboring curl invocation. Probably a remnant of using wget.)