### PR TITLE
Fix stale bup appcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM php:7-apache
 RUN apt-get update && apt-get -y install unzip
 RUN docker-php-ext-install mysqli
 
+# Enable mod_headers, primarily to avoid caching bup appcache files
+RUN a2enmod headers
+
 # download and unzip current CourtSpot
 RUN curl 'https://www.courtspot.de/Downloads/CourtSpot.zip' -o /var/www/html/CourtSpot.zip
 RUN unzip /var/www/html/CourtSpot.zip -d  /var/www/html/


### PR DESCRIPTION
When Chrome caches an HTML5 Offline Web Applications index, it is impossible to update to a newer version, as the cached index is (somewhat rightfully) used to determine whether to load new sources.

The easiest way to detect this is run a bupdate (or rebuild the docker image, which does this as well), and look at the version number in bup (bottom right).
If the problem described here is manifesting itself, the version number will still be old (from 2017).

The fix is to add an HTTP header preventing caching of the appcache file.
bup includes an .htaccess file, but that requires mod_header. Therefore, enable mod_header.

To rescue an affected Chrome instance, manually delete the appcache in chrome://appcache-internals .